### PR TITLE
Add mailto submission for contact form

### DIFF
--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -12,7 +12,21 @@ const Contact = () => {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    // Form submission logic would go here
+    const { name, email, company, message } = formData;
+    const subject = `Yeni Proje Başvurusu - ${company || 'Şahıs'}`;
+    const bodyLines = [
+      `Ad Soyad: ${name}`,
+      `E-posta: ${email}`,
+      company ? `Şirket/Kurum: ${company}` : undefined,
+      '',
+      'Mesaj:',
+      message,
+    ].filter(Boolean);
+    const body = bodyLines.join('\n');
+
+    window.location.href =
+      `mailto:info@charqe.io?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+
     setIsSubmitted(true);
     setTimeout(() => setIsSubmitted(false), 3000);
   };


### PR DESCRIPTION
## Summary
- send the contact form data using a `mailto:` link to `info@charqe.io`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ea8789cd0832b8a2e7dda06ad2b27