### PR TITLE
Enable SMTP-based contact form

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
-SMTP_HOST=smtp.example.com
-SMTP_PORT=465
-SMTP_USER=username
-SMTP_PASS=password
-CONTACT_EMAIL=info@charqe.io
+SMTP_HOST=mail.charqe.io
+SMTP_PORT=587
+SMTP_USER=noreply@charqe.io
+SMTP_PASS=nosxyn-pIjnis-0repwu
+CONTACT_EMAIL=noreply@charqe.io

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+SMTP_HOST=smtp.example.com
+SMTP_PORT=465
+SMTP_USER=username
+SMTP_PASS=password
+CONTACT_EMAIL=info@charqe.io

--- a/package.json
+++ b/package.json
@@ -7,12 +7,16 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "server": "node server/index.js"
   },
   "dependencies": {
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "express": "^4.18.2",
+    "nodemailer": "^6.9.13",
+    "dotenv": "^16.3.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,55 @@
+import express from 'express';
+import nodemailer from 'nodemailer';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const app = express();
+const port = process.env.PORT || 3001;
+
+app.use(express.json());
+
+app.post('/api/contact', async (req, res) => {
+  const { name, email, company, message } = req.body;
+  if (!name || !email || !message) {
+    return res.status(400).json({ error: 'Missing fields' });
+  }
+
+  try {
+    const transporter = nodemailer.createTransport({
+      host: process.env.SMTP_HOST,
+      port: Number(process.env.SMTP_PORT) || 465,
+      secure: true,
+      auth: {
+        user: process.env.SMTP_USER,
+        pass: process.env.SMTP_PASS,
+      },
+    });
+
+    const mailOptions = {
+      from: `"${name}" <${email}>`,
+      to: process.env.CONTACT_EMAIL || 'info@charqe.io',
+      subject: `Yeni Proje Başvurusu - ${company || 'Şahıs'}`,
+      text: [
+        `Ad Soyad: ${name}`,
+        `E-posta: ${email}`,
+        company ? `Şirket/Kurum: ${company}` : undefined,
+        '',
+        'Mesaj:',
+        message,
+      ]
+        .filter(Boolean)
+        .join('\n'),
+    };
+
+    await transporter.sendMail(mailOptions);
+    res.status(200).json({ success: true });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Mail gönderilemedi' });
+  }
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});

--- a/server/index.js
+++ b/server/index.js
@@ -16,10 +16,11 @@ app.post('/api/contact', async (req, res) => {
   }
 
   try {
+    const port = Number(process.env.SMTP_PORT) || 465;
     const transporter = nodemailer.createTransport({
       host: process.env.SMTP_HOST,
-      port: Number(process.env.SMTP_PORT) || 465,
-      secure: true,
+      port,
+      secure: port === 465,
       auth: {
         user: process.env.SMTP_USER,
         pass: process.env.SMTP_PASS,
@@ -27,8 +28,9 @@ app.post('/api/contact', async (req, res) => {
     });
 
     const mailOptions = {
-      from: `"${name}" <${email}>`,
-      to: process.env.CONTACT_EMAIL || 'info@charqe.io',
+      from: process.env.CONTACT_EMAIL || process.env.SMTP_USER,
+      replyTo: `"${name}" <${email}>`,
+      to: process.env.CONTACT_EMAIL || process.env.SMTP_USER,
       subject: `Yeni Proje Başvurusu - ${company || 'Şahıs'}`,
       text: [
         `Ad Soyad: ${name}`,

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -10,25 +10,24 @@ const Contact = () => {
   });
   const [isSubmitted, setIsSubmitted] = useState(false);
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const { name, email, company, message } = formData;
-    const subject = `Yeni Proje Başvurusu - ${company || 'Şahıs'}`;
-    const bodyLines = [
-      `Ad Soyad: ${name}`,
-      `E-posta: ${email}`,
-      company ? `Şirket/Kurum: ${company}` : undefined,
-      '',
-      'Mesaj:',
-      message,
-    ].filter(Boolean);
-    const body = bodyLines.join('\n');
 
-    window.location.href =
-      `mailto:info@charqe.io?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+    const response = await fetch('/api/contact', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(formData),
+    });
 
-    setIsSubmitted(true);
-    setTimeout(() => setIsSubmitted(false), 3000);
+    if (response.ok) {
+      setIsSubmitted(true);
+      setFormData({ name: '', email: '', company: '', message: '' });
+      setTimeout(() => setIsSubmitted(false), 3000);
+    } else {
+      alert('Mesaj gönderilemedi. Lütfen daha sonra tekrar deneyin.');
+    }
   };
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,4 +7,9 @@ export default defineConfig({
   optimizeDeps: {
     exclude: ['lucide-react'],
   },
+  server: {
+    proxy: {
+      '/api': 'http://localhost:3001',
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- add an example environment file for SMTP credentials
- use a Node-based server with nodemailer
- proxy `/api` requests through Vite to the server
- update contact form to send POST requests rather than `mailto:`
- register server script and dependencies

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ea9c4664c832ba9d099b42b6e1cd0